### PR TITLE
feat(#7): 이미지의 결과 화면 및 기능 구현

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -6,7 +6,7 @@ const Result = () => {
   const imageUrl = localStorage.getItem("generatedImageUrl") ?? "";
   const email = localStorage.getItem("email") || "";
 
-  // 현재는 기본 크레딧 25 기준으로, 이미지 생성 최대 8회로 고정 처리 중입니다.
+  // ⚠️ 현재는 기본 크레딧 25 기준으로, 이미지 생성 최대 8회로 고정 처리 중입니다.
   // TODO: 잔여 크레딧 기반으로 수정 예정 (Stability API 사용자 크레딧 조회 연동 시)
   const usageKey = `usageCount_${email}`;
   const usageCount = parseInt(localStorage.getItem(usageKey) || "0", 10);

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,27 +1,11 @@
-import { useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+const username = localStorage.getItem("username") || "";
+const usageKey = `usageCount_${username}`;
+const usageCount = parseInt(localStorage.getItem(usageKey) || "0", 10);
+const remaining = 8 - usageCount;
 
-const Result = () => {
-  const navigate = useNavigate();
-  const imageUrl = localStorage.getItem("generatedImageUrl") ?? "";
+...
 
-  useEffect(() => {
-    if (!imageUrl) {
-      alert("이미지가 존재하지 않습니다.");
-      navigate("/input");
-    }
-  }, [imageUrl, navigate]);
-
-  return (
-    <div className="w-screen h-screen flex flex-col items-center justify-center bg-gradient-to-br from-yellow-100 to-pink-100 px-4">
-      <h2 className="text-5xl font-bold text-pink-600 mb-8">🎉 결과 이미지</h2>
-      <img
-        src={imageUrl}
-        alt="생성된 아바타"
-        className="w-[350px] h-[350px] rounded-xl shadow-lg object-cover mb-6"
-      />
-    </div>
-  );
-};
-
-export default Result;
+<p className="text-xl text-gray-700 mb-6">
+  남은 이미지 생성 가능 횟수:{" "}
+  <span className="text-pink-500 font-bold text-2xl">{remaining}</span> / 8
+</p>

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,11 +1,51 @@
-const username = localStorage.getItem("username") || "";
-const usageKey = `usageCount_${username}`;
-const usageCount = parseInt(localStorage.getItem(usageKey) || "0", 10);
-const remaining = 8 - usageCount;
+const handleDownload = async () => {
+  try {
+    const response = await fetch(imageUrl);
+    const blob = await response.blob();
+    const blobUrl = URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+    link.href = blobUrl;
+    link.download = "avatar_result.jpeg";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(blobUrl);
+  } catch (err) {
+    alert("이미지 다운로드에 실패했습니다.");
+    console.error(err);
+  }
+};
+
+const handleRetry = () => {
+  navigate("/input");
+};
+
+const handleGoHome = () => {
+  navigate("/");
+};
 
 ...
 
-<p className="text-xl text-gray-700 mb-6">
-  남은 이미지 생성 가능 횟수:{" "}
-  <span className="text-pink-500 font-bold text-2xl">{remaining}</span> / 8
-</p>
+<div className="flex gap-6">
+  <button
+    onClick={handleDownload}
+    className="bg-pink-500 hover:bg-pink-600 text-white font-semibold px-6 py-3 rounded-full shadow-md text-lg transition"
+  >
+    다운로드
+  </button>
+
+  <button
+    onClick={handleRetry}
+    className="bg-white text-pink-600 border border-pink-400 font-semibold px-6 py-3 rounded-full shadow-md text-lg hover:bg-pink-50 transition"
+  >
+    다시 생성하기
+  </button>
+
+  <button
+    onClick={handleGoHome}
+    className="bg-gray-100 text-gray-700 border border-gray-300 font-semibold px-6 py-3 rounded-full shadow-md text-lg hover:bg-gray-200 transition"
+  >
+    홈으로
+  </button>
+</div>

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,0 +1,27 @@
+import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+
+const Result = () => {
+  const navigate = useNavigate();
+  const imageUrl = localStorage.getItem("generatedImageUrl") ?? "";
+
+  useEffect(() => {
+    if (!imageUrl) {
+      alert("이미지가 존재하지 않습니다.");
+      navigate("/input");
+    }
+  }, [imageUrl, navigate]);
+
+  return (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-gradient-to-br from-yellow-100 to-pink-100 px-4">
+      <h2 className="text-5xl font-bold text-pink-600 mb-8">🎉 결과 이미지</h2>
+      <img
+        src={imageUrl}
+        alt="생성된 아바타"
+        className="w-[350px] h-[350px] rounded-xl shadow-lg object-cover mb-6"
+      />
+    </div>
+  );
+};
+
+export default Result;

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,51 +1,17 @@
-const handleDownload = async () => {
-  try {
-    const response = await fetch(imageUrl);
-    const blob = await response.blob();
-    const blobUrl = URL.createObjectURL(blob);
+const Result = () => {
+  const navigate = useNavigate();
+  const imageUrl = localStorage.getItem("generatedImageUrl") ?? "";
+  const email = localStorage.getItem("email") || "";
 
-    const link = document.createElement("a");
-    link.href = blobUrl;
-    link.download = "avatar_result.jpeg";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(blobUrl);
-  } catch (err) {
-    alert("이미지 다운로드에 실패했습니다.");
-    console.error(err);
-  }
-};
+  // 현재는 기본 크레딧 25 기준으로, 이미지 생성 최대 8회로 고정 처리
+  // TODO: Stability API의 사용자 크레딧 조회 기능 연동 시 잔여 크레딧 기반으로 수정 예정
+  const usageKey = usageCount_${email};
+  const usageCount = parseInt(localStorage.getItem(usageKey) || "0", 10);
+  const remaining = 8 - usageCount;
 
-const handleRetry = () => {
-  navigate("/input");
-};
-
-const handleGoHome = () => {
-  navigate("/");
-};
-
-...
-
-<div className="flex gap-6">
-  <button
-    onClick={handleDownload}
-    className="bg-pink-500 hover:bg-pink-600 text-white font-semibold px-6 py-3 rounded-full shadow-md text-lg transition"
-  >
-    다운로드
-  </button>
-
-  <button
-    onClick={handleRetry}
-    className="bg-white text-pink-600 border border-pink-400 font-semibold px-6 py-3 rounded-full shadow-md text-lg hover:bg-pink-50 transition"
-  >
-    다시 생성하기
-  </button>
-
-  <button
-    onClick={handleGoHome}
-    className="bg-gray-100 text-gray-700 border border-gray-300 font-semibold px-6 py-3 rounded-full shadow-md text-lg hover:bg-gray-200 transition"
-  >
-    홈으로
-  </button>
-</div>
+  useEffect(() => {
+    if (!imageUrl) {
+      alert("이미지가 존재하지 않습니다.");
+      navigate("/input");
+    }
+  }, [imageUrl, navigate]);

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,11 +1,14 @@
+import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+
 const Result = () => {
   const navigate = useNavigate();
   const imageUrl = localStorage.getItem("generatedImageUrl") ?? "";
   const email = localStorage.getItem("email") || "";
 
-  // 현재는 기본 크레딧 25 기준으로, 이미지 생성 최대 8회로 고정 처리
-  // TODO: Stability API의 사용자 크레딧 조회 기능 연동 시 잔여 크레딧 기반으로 수정 예정
-  const usageKey = usageCount_${email};
+  // 현재는 기본 크레딧 25 기준으로, 이미지 생성 최대 8회로 고정 처리 중입니다.
+  // TODO: 잔여 크레딧 기반으로 수정 예정 (Stability API 사용자 크레딧 조회 연동 시)
+  const usageKey = `usageCount_${email}`;
   const usageCount = parseInt(localStorage.getItem(usageKey) || "0", 10);
   const remaining = 8 - usageCount;
 
@@ -15,3 +18,73 @@ const Result = () => {
       navigate("/input");
     }
   }, [imageUrl, navigate]);
+
+  const handleDownload = async () => {
+    try {
+      const response = await fetch(imageUrl);
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.download = "avatar_result.jpeg";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(blobUrl);
+    } catch (err) {
+      alert("이미지 다운로드에 실패했습니다.");
+      console.error(err);
+    }
+  };
+
+  const handleRetry = () => {
+    navigate("/input");
+  };
+
+  const handleGoHome = () => {
+    navigate("/");
+  };
+
+  return (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-gradient-to-br from-yellow-100 to-pink-100 px-4">
+      <h2 className="text-5xl font-bold text-pink-600 mb-8">🎉 결과 이미지</h2>
+
+      <img
+        src={imageUrl}
+        alt="생성된 아바타"
+        className="w-[350px] h-[350px] rounded-xl shadow-lg object-cover mb-6"
+      />
+
+      <p className="text-xl text-gray-700 mb-6">
+        남은 이미지 생성 가능 횟수:{" "}
+        <span className="text-pink-500 font-bold text-2xl">{remaining}</span> / 8
+      </p>
+
+      <div className="flex gap-6">
+        <button
+          onClick={handleDownload}
+          className="bg-pink-500 hover:bg-pink-600 text-white font-semibold px-6 py-3 rounded-full shadow-md text-lg transition"
+        >
+          다운로드
+        </button>
+
+        <button
+          onClick={handleRetry}
+          className="bg-white text-pink-600 border border-pink-400 font-semibold px-6 py-3 rounded-full shadow-md text-lg hover:bg-pink-50 transition"
+        >
+          다시 생성하기
+        </button>
+
+        <button
+          onClick={handleGoHome}
+          className="bg-gray-100 text-gray-700 border border-gray-300 font-semibold px-6 py-3 rounded-full shadow-md text-lg hover:bg-gray-200 transition"
+        >
+          홈으로
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Result;


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- #7 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text

```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

![스크린샷 2025-05-17 000019](https://github.com/user-attachments/assets/31cfc7d4-3ad0-49c4-8bfd-1559a324daca)
이미지가 생성되면 결과 화면이 뜨고, 이 이미지의 결과를 다운로드 할 수 있고 다시 생성할 수 있으며, 그리고 홈으로 이동할 수 있다.
또한, 인당 8번 이미지 생성을 할 수 있기 때문에 몇 번 더 생성 할 수 있는지 메시지를 통해 보여준다.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```
