### PR TITLE
feat(#8): 보관함 화면 및 기능 구현

### DIFF
--- a/src/pages/Storage.tsx
+++ b/src/pages/Storage.tsx
@@ -1,13 +1,8 @@
-const handleDownload = (url: string, index: number) => {
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = `avatar_${index + 1}.png`;
-  link.click();
-};
+const navigate = useNavigate();
 
 <button
-  onClick={() => handleDownload(img, index)}
-  className="mt-4 bg-pink-500 hover:bg-pink-600 text-white font-semibold py-1.5 px-6 rounded-full"
+  onClick={() => navigate("/")}
+  className="mt-12 bg-gray-700 hover:bg-gray-800 text-white px-8 py-3 rounded-full shadow-md text-lg transition"
 >
-  다운로드
+  홈으로
 </button>

--- a/src/pages/Storage.tsx
+++ b/src/pages/Storage.tsx
@@ -1,46 +1,13 @@
-import { useNavigate } from "react-router-dom";
-
-const Storage = () => {
-  // 가짜 데이터: 현재 저장된 아바타 3개 (임시)
-  const savedImages = [
-    "https://via.placeholder.com/300x300.png?text=Avatar+1",
-    "https://via.placeholder.com/300x300.png?text=Avatar+2",
-    "https://via.placeholder.com/300x300.png?text=Avatar+3",
-  ];
-
-  const maxSlots = 8;
-  const imageSlots = Array.from({ length: maxSlots }, (_, i) => savedImages[i] || null);
-
-  return (
-    <div className="w-screen min-h-screen bg-gradient-to-br from-yellow-100 to-pink-100 py-16 flex flex-col items-center">
-      <h2 className="text-4xl font-bold text-pink-600 mb-10 flex items-center gap-2">
-        📦 보관함
-      </h2>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8 px-4">
-        {imageSlots.map((img, index) => (
-          <div
-            key={index}
-            className="w-[220px] h-[280px] bg-white rounded-xl shadow-lg flex flex-col items-center justify-center p-4 text-gray-400"
-          >
-            {img ? (
-              <img
-                src={img}
-                alt={`아바타 ${index + 1}`}
-                className="w-full h-[200px] object-cover rounded-lg"
-              />
-            ) : (
-              <>
-                <div className="text-5xl">📁</div>
-                <p className="mt-4">빈 슬롯</p>
-              </>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+const handleDownload = (url: string, index: number) => {
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `avatar_${index + 1}.png`;
+  link.click();
 };
 
-export default Storage;
-
+<button
+  onClick={() => handleDownload(img, index)}
+  className="mt-4 bg-pink-500 hover:bg-pink-600 text-white font-semibold py-1.5 px-6 rounded-full"
+>
+  다운로드
+</button>

--- a/src/pages/Storage.tsx
+++ b/src/pages/Storage.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from "react-router-dom";
+
+const Storage = () => {
+  // 가짜 데이터: 현재 저장된 아바타 3개 (임시)
+  const savedImages = [
+    "https://via.placeholder.com/300x300.png?text=Avatar+1",
+    "https://via.placeholder.com/300x300.png?text=Avatar+2",
+    "https://via.placeholder.com/300x300.png?text=Avatar+3",
+  ];
+
+  const maxSlots = 8;
+  const imageSlots = Array.from({ length: maxSlots }, (_, i) => savedImages[i] || null);
+
+  return (
+    <div className="w-screen min-h-screen bg-gradient-to-br from-yellow-100 to-pink-100 py-16 flex flex-col items-center">
+      <h2 className="text-4xl font-bold text-pink-600 mb-10 flex items-center gap-2">
+        📦 보관함
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8 px-4">
+        {imageSlots.map((img, index) => (
+          <div
+            key={index}
+            className="w-[220px] h-[280px] bg-white rounded-xl shadow-lg flex flex-col items-center justify-center p-4 text-gray-400"
+          >
+            {img ? (
+              <img
+                src={img}
+                alt={`아바타 ${index + 1}`}
+                className="w-full h-[200px] object-cover rounded-lg"
+              />
+            ) : (
+              <>
+                <div className="text-5xl">📁</div>
+                <p className="mt-4">빈 슬롯</p>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Storage;
+


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- #8 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text

```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.
![스크린샷 2025-05-17 002539](https://github.com/user-attachments/assets/6aaa35c2-c46b-4b2a-805a-f227e6c7d99a)
홈에서 보관함 버튼을 누르면 이 화면으로 오게되는데, 이 화면에는 그동안 생성했던 이미지의 결과들이 자동 저장되는 곳이다.
사용자 당 최대 8번 생성할 수 있기 때문에 보관함의 개수는 8개로 하였고, 각 이미지에 대해 다운로드를 받을 수 있다.
(현재는 임시적으로 3개만 저장하였다)

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```
